### PR TITLE
Fix: Rename pages to project name, remove extra header and move logo …

### DIFF
--- a/src/content/docs/guides/cardano-node-api/001-cardano-node-api.md
+++ b/src/content/docs/guides/cardano-node-api/001-cardano-node-api.md
@@ -1,9 +1,9 @@
 ---
-title: Overview
+title: Cardano Node API
 description: A guide about Cardano Node API.
 ---
 
-# Cardano Node API
+![cardano-node-api-logo](/cardano-node-api-logo.png)
 
 An HTTP API for interfacing with a local Cardano Node and providing the node internal data for HTTP clients. This service communicates with a Cardano full node using the Ouroboros network protocol via a UNIX socket and exposes the underlying Node-to-Client (NtC) Ouroboros mini-protocols to clients via a REST API or UTxO RPC gRPC API.  
 
@@ -20,4 +20,4 @@ Simply download the Cardano Node API binary file from blinklabs.io on to your no
 
 ✅ Get started with our [Quick Start](../002-quick-start) guide to start using Cardano Node API.
 
-![cardano-node-api-logo](/cardano-node-api-logo.png)
+

--- a/src/content/docs/guides/cardano-up/001-cardano-up.md
+++ b/src/content/docs/guides/cardano-up/001-cardano-up.md
@@ -3,10 +3,8 @@ title: cardano-up
 description: A guide about cardano-up.
 ---
 
-
 Command line utility for managing Cardano services. cardano-up allows you to use a command line utility to install Cardano services by using docker images.
 
-<br>
 
 # Why use cardano-up?
 

--- a/src/content/docs/guides/cardano-up/001-cardano-up.md
+++ b/src/content/docs/guides/cardano-up/001-cardano-up.md
@@ -1,9 +1,8 @@
 ---
-title: Overview
+title: cardano-up
 description: A guide about cardano-up.
 ---
 
-# cardano-up
 
 Command line utility for managing Cardano services. cardano-up allows you to use a command line utility to install Cardano services by using docker images.
 

--- a/src/content/docs/guides/nview/001-nview.md
+++ b/src/content/docs/guides/nview/001-nview.md
@@ -3,6 +3,8 @@ title: nview
 description: Introduction to nview.
 ---
 
+![nview-screen](/nview-screen.png)
+
 nview is a local monitoring tool for a Cardano Node (cardano-node) meant to complement remote monitoring tools by providing a local view of a running node from the command line. It is a TUI (terminal user interface) designed to fit most screens. 
 
 Running nview against a running Cardano Node will work out of the box with a default Cardano Node configuration, which exposes metrics in Prometheus data format on a specific port. However, if you need to make change you can run nview with a configuration file. 
@@ -12,5 +14,5 @@ Simply download the nview binary file from blinklabs.io on to your node server. 
 
 ✅ Get started with our [Quick Start](../002-quick-start) guide and start monitoring your node with nview.
 
-![nview-screen](/nview-screen.png)
+
 

--- a/src/content/docs/guides/txsubmit/001-tx-submit-api.md
+++ b/src/content/docs/guides/txsubmit/001-tx-submit-api.md
@@ -1,9 +1,9 @@
 ---
-title: Overview
+title: Tx Submit API
 description: A guide about Tx Submit API.
 ---
 
-# Tx Submit API
+![txsubmit-logo](/txsubmit-logo.png)
 
 Tx Submit API is a Cardano transaction submit API service written in Go which takes CBOR encoded transaction payloads over HTTP and converts it to the Ouroboros Network LocalTxSubmission mini-protocol via gOuroboros. This project was funded in Project Catalyst Fund 9.
 
@@ -13,6 +13,3 @@ Tx Submit API submits transactions over HTTP making it a faster option for submi
 Simply download the Tx Submit API binary file from blinklabs.io on to your node server. Then run Tx Submit API in the server command line. Configuration can be done using a config file or setting environment variables
 
 ✅ Get started with our [Quick Start](../002-quick-start) guide to start submitting transactions over HTTP using Tx Submit API.
-
-![txsubmit-logo](/txsubmit-logo.png)
-

--- a/src/content/docs/guides/txtop/001-tx-top.md
+++ b/src/content/docs/guides/txtop/001-tx-top.md
@@ -1,9 +1,9 @@
 ---
-title: Overview
+title: TxTop
 description: A guide about TxTop.
 ---
 
-# TxTop
+![txtop-screen](/txtop-screen.png)
 
 TxTop is a mempool inspector for Cardano Node software.
 
@@ -17,5 +17,3 @@ You can use TxTop as a local monitoring tool for a Cardano Node (cardano-node) m
 Simply download the TxTop binary file from blinklabs.io on to your node server. Then run TxTop in the server command line. It's that simple to use and gives you the ability to inspecting your Cardano Node's mempool with at-a-glance simple icons! 
 
 ✅ Get started with our [Quick Start](../002-quick-start) guide and start using TxTop to view you node's mempool.
-
-![txtop-screen](/txtop-screen.png)


### PR DESCRIPTION
…to top across project guides

Fix: Rename pages to project name, remove extra header and move logo to top across project guides