### PR TITLE
feat: Add Release Notes for Dingo and Bursa

### DIFF
--- a/src/content/docs/guides/bursa/Releases/001-Release-Notes.md
+++ b/src/content/docs/guides/bursa/Releases/001-Release-Notes.md
@@ -3,7 +3,7 @@ title: Latest Releases
 description: Bursa Release Notes
 ---
 
-## Keep your Bursa Wallet current to ensure you're always running the latest performance boosts💪, new features✨, critical fixes🛠️, and security enhancements🔐. 
+## Keep your Bursa Wallet current to ensure you're always running the latest performance boosts💪, new features✨, critical fixes🔧, and security enhancements🔐. 
 
 <br>
 

--- a/src/content/docs/guides/bursa/Releases/001-Release-Notes.md
+++ b/src/content/docs/guides/bursa/Releases/001-Release-Notes.md
@@ -1,0 +1,12 @@
+---
+title: Latest Releases
+description: Bursa Release Notes
+---
+
+## Keep your Bursa Wallet current to ensure you're always running the latest performance boosts💪, new features✨, critical fixes🛠️, and security enhancements🔐. 
+
+<br>
+
+☑️ Select a version below to view the full release notes.
+
+- Version: v0.16.0 - *[View Release Notes](../002-v0-16-0)*

--- a/src/content/docs/guides/bursa/Releases/002-v0-16-0.md
+++ b/src/content/docs/guides/bursa/Releases/002-v0-16-0.md
@@ -1,0 +1,30 @@
+---
+title: Release Notes - v0.16.0
+description: Bursa Release Notes - v0.16.0
+---
+
+## v0.16.0 - certificate generation and key derivation
+
+- **Date:** 2026-02-28
+- **Version:** 0.16.0
+
+### Summary
+
+This release includes CLI support for generating stake and Conway governance certificates and updates wallet root key derivation to Cardano `CIP-3` Icarus, along with security and dependency updates.
+
+### ✨ New Features
+
+- Added CLI support for generating stake and Conway governance certificates.
+
+### ⛓️‍💥 Breaking Changes
+
+- Updated wallet root key derivation to follow Cardano `CIP-3` Icarus (PBKDF2), which requires regenerating derived keys and updating any stored test vectors.
+
+### 🔐 Security
+
+- Updated cryptography and secret-management dependencies including `filippo.io/edwards25519` to `v1.2.0`, `github.com/cloudflare/circl` to `v1.6.3`, `github.com/ethereum/go-ethereum` to `v1.17.0`, and `sops` to `v3.12.1`.
+
+### Additional Changes
+
+- Updated Go modules including `gouroboros`, `plutigo`, and `grpc`, bumped GitHub Actions `docker/build-push-action` to `v6.19.2`, and updated the `blinklabs-io/go` Docker base image to `1.25.7-1`.
+- Updated lint-suppression annotations for selected security checks and updated `.gitignore` to exclude `.worktrees/`.

--- a/src/content/docs/guides/dingo/Releases/001-Release-Notes.md
+++ b/src/content/docs/guides/dingo/Releases/001-Release-Notes.md
@@ -3,7 +3,7 @@ title: Latest Releases
 description: Dingo Release Notes
 ---
 
-📦 Stay up to date with the most recent releases of the Dingo Node. New releases often include ✨ performance improvements, 💪 new features, and/or important 🛠️ fixes. 
+## Keep your Dingo Node current to ensure you're always running the latest performance boosts💪, new features✨, and critical fixes🛠️. 
 
 <br>
 

--- a/src/content/docs/guides/dingo/Releases/001-Release-Notes.md
+++ b/src/content/docs/guides/dingo/Releases/001-Release-Notes.md
@@ -1,0 +1,10 @@
+---
+title: Dingo
+description: Release Notes
+---
+
+# Latest Releases
+
+Stay up to date with the most recent releases of Dingo Node. New releases often include performance improvements, new features, and/or important fixes. Select a version below to view the full release notes.
+
+- Version: v0.39.1 - *[View Release Notes](../002-v0-39-1)*

--- a/src/content/docs/guides/dingo/Releases/001-Release-Notes.md
+++ b/src/content/docs/guides/dingo/Releases/001-Release-Notes.md
@@ -3,7 +3,7 @@ title: Latest Releases
 description: Dingo Release Notes
 ---
 
-## Keep your Dingo Node current to ensure you're always running the latest performance boosts💪, new features✨, and critical fixes🛠️. 
+## Keep your Dingo Node current to ensure you're always running the latest performance boosts💪, new features✨, and critical fixes🔧. 
 
 <br>
 

--- a/src/content/docs/guides/dingo/Releases/001-Release-Notes.md
+++ b/src/content/docs/guides/dingo/Releases/001-Release-Notes.md
@@ -3,6 +3,10 @@ title: Latest Releases
 description: Dingo Release Notes
 ---
 
-Stay up to date with the most recent releases of Dingo Node. New releases often include performance improvements, new features, and/or important fixes. Select a version below to view the full release notes.
+📦 Stay up to date with the most recent releases of the Dingo Node. New releases often include ✨ performance improvements, 💪 new features, and/or important 🛠️ fixes. 
+
+<br>
+
+☑️ Select a version below to view the full release notes.
 
 - Version: v0.39.1 - *[View Release Notes](../002-v0-39-1)*

--- a/src/content/docs/guides/dingo/Releases/001-Release-Notes.md
+++ b/src/content/docs/guides/dingo/Releases/001-Release-Notes.md
@@ -1,9 +1,7 @@
 ---
-title: Dingo
-description: Release Notes
+title: Latest Releases
+description: Dingo Release Notes
 ---
-
-# Latest Releases
 
 Stay up to date with the most recent releases of Dingo Node. New releases often include performance improvements, new features, and/or important fixes. Select a version below to view the full release notes.
 

--- a/src/content/docs/guides/dingo/Releases/002-v0-39-1.md
+++ b/src/content/docs/guides/dingo/Releases/002-v0-39-1.md
@@ -1,0 +1,48 @@
+---
+title: Release Notes - v0.39.1
+description: Dingo Release Notes - v0.39.1
+---
+
+## v0.39.1 (May 1, 2026)
+
+**Title:** Safer pruning, rollback recovery, and snapshot nonces
+
+**Date:** May 1, 2026
+
+**Version:** v0.39.1
+
+Hi folks! Here’s what we shipped in v0.39.1.
+
+### ✨ What's New
+
+* Noted **no new features:** This patch release focuses on improvements and fixes.
+
+### 💪 Improvements
+
+* Refined **archive aware Bark cleanup behavior:** Archived blocks now remain resolvable during prune and cleanup work because Bark leaves archive aware tombstones in place and reads honor them.
+
+### 🔧 Fixes
+
+* Preserved **safer rollback cleanup near the Mithril boundary:** Rollback cleanup now keeps gap UTxOs intact near the Mithril boundary, which makes rollback recovery safer.
+* Hardened **archive aware Bark cleanup handling:** Bark pruning and archival handling now preserve the resolvability of archived blocks during cleanup.
+* Corrected **snapshot bootstrap nonce handling across state layouts:** Snapshot bootstrap now reads epoch and snapshot nonces correctly across supported state layouts, which keeps epoch boundary validation correct after bootstrap.
+
+### 📋 What You Need to Know
+
+* Clarified **patch release upgrade guidance:** This is a patch release, and normal upgrade procedures are sufficient for most operators and users.
+* Highlighted **safer pruning and rollback recovery:** Bark pruning now preserves resolvable live UTxOs, and Mithril boundary rollback recovery now preserves the required gap block state for safe recovery.
+* Corrected **snapshot nonce handling after bootstrap:** Snapshot bootstrapped nodes now read the right nonce data across supported snapshot layouts so epoch boundary header and VRF validation continue correctly after bootstrap.
+
+### Recommended Network Compatibility ⚠️
+
+| Network             | Compatible |
+|---------------------|------------|
+| mainnet             | ⛔         |
+| preprod-testnet     | ⛔         |
+| preview-testnet     | ✅         |
+
+### 🙏 Thank You
+
+Thank you for trying!
+
+---


### PR DESCRIPTION
Fix: Add Release Notes for Dingo and Bursa

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added “Latest Releases” pages for Dingo Node and Bursa Wallet docs with version links to full notes (Dingo v0.39.1, Bursa v0.16.0).

Dingo: patch focused on archive‑aware Bark cleanup, safer rollback near the Mithril boundary, and correct snapshot bootstrap nonce handling; compatibility limited to `preview-testnet`. Bursa: CLI support for stake and Conway governance certificate generation, switch to Cardano `CIP-3` Icarus root key derivation (breaking, re‑derive keys), and security/dependency updates.

<sup>Written for commit 3ad770f564fcad130d6900c23068efb5a1be01d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* **Bursa v0.16.0 Release Notes**: New CLI features for stake and governance certificates, security updates, and wallet key derivation changes now available.
* **Dingo v0.39.1 Release Notes**: Improved block pruning and rollback recovery, corrected snapshot handling, with network compatibility guidance for operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->