### PR TITLE
Feat: Add Plutigo to Docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -58,6 +58,7 @@ export default defineConfig({
 						{ label: 'Tx Submit API Mirror', collapsed: true, autogenerate: { directory: 'guides/txsubmit-api-mirror' } },
 						{ label: 'cDNSd', collapsed: true, slug: 'guides/cdnsd' },
 						{ label: 'gOuroboros', collapsed: true, autogenerate: { directory: 'guides/gouroboros' } },
+						{ label: 'plutigo', collapsed: true, autogenerate: { directory: 'guides/plutigo' } },
 						{ label: 'Docker Images', collapsed: true, slug: 'guides/docker-images' },
 					],
 				},


### PR DESCRIPTION
Feat: Add Plutigo to Docs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the `plutigo` guide to the docs sidebar to make the new content easy to find. It’s collapsed by default and auto-generates from `guides/plutigo`.

<sup>Written for commit 2c29a57974382d897b9d9f6cf00e31b9a937201e. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/docs/pull/231?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new collapsible "plutigo" guide section to the sidebar navigation with automatically generated content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/docs/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->